### PR TITLE
Added Composers fallback directories to map

### DIFF
--- a/src/Dflydev/Psr0ResourceLocator/Composer/ComposerResourceLocator.php
+++ b/src/Dflydev/Psr0ResourceLocator/Composer/ComposerResourceLocator.php
@@ -38,6 +38,11 @@ class ComposerResourceLocator extends AbstractPsr0ResourceLocator
      */
     protected function loadMap()
     {
-        return $this->classLoaderLocator->getReader()->getPrefixes();
+        $reader = $this->classLoaderLocator->getReader();
+
+        $prefixes = $reader->getPrefixes();
+        $prefixes[""] = $reader->getFallbackDirs();
+
+        return $prefixes;
     }
 }

--- a/tests/Dflydev/Psr0ResourceLocator/Composer/ComposerResourceLocatorTest.php
+++ b/tests/Dflydev/Psr0ResourceLocator/Composer/ComposerResourceLocatorTest.php
@@ -40,6 +40,11 @@ class ComposerResourceLocatorTest extends \PHPUnit_Framework_TestCase
                 'Dflydev\Psr0ResourceLocator\Composer' => array(realpath(__DIR__.'/../../..')),
             )));
 
+        $reader
+            ->expects($this->once())
+            ->method('getFallbackDirs')
+            ->will($this->returnValue(array()));
+
         $classLoaderLocator = $this->getMock('Dflydev\Composer\Autoload\ClassLoaderLocator');
 
         $classLoaderLocator


### PR DESCRIPTION
Composer fallback directories will now be added to the `namespace => directory` map, with an empty (`""`) key.

The `AbstractPsr0ResourceLocator` is changed to check this entry as well, see https://github.com/dflydev/dflydev-psr0-resource-locator/pull/1.
